### PR TITLE
CPU 폭주/고아 프로세스 방지

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tobedoit/google-calendar-mcp",
-  "version": "1.1.15",
+  "version": "1.1.16",
   "description": "MCP server implementation for Google Calendar integration",
   "type": "module",
   "bin": {


### PR DESCRIPTION
- `npx -y @tobedoit/google-calendar-mcp` 로 실행해도 **고아 프로세스 방지**
- **idle 타임아웃** 추가 (`MCP_IDLE_TIMEOUT_MS` 환경변수로 조정 가능, 기본 10분 정도로 길게 잡음. 더 과감히 줄이고 싶으면 30초/1분 정도로 줄여도 됨)
- **stdin `end`/`close` 이벤트 처리** → 클라이언트/파이프 끊기면 바로 종료
- stdout은 그대로 JSON-RPC만 쓰고, 로그는 stderr만 사용 (기존 유지)
- Fixes #2