### PR TITLE
claude 클라이언트 재실행

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tobedoit/google-calendar-mcp",
-  "version": "1.1.16",
+  "version": "1.1.17",
   "description": "MCP server implementation for Google Calendar integration",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Idle timeout 종료 시 exit(1) 사용 (중요)
- Idle 타임아웃 발생 시 process.exit(1)로 종료
- Claude/ChatGPT/MCP 클라이언트는 이를 “비정상 종료”로 판단
- 다음 MCP 호출 시 자동으로 새 프로세스를 실행
- 오래 안 써도 항상 다시 사용 가능
- Fixes #4 