### PR TITLE
idle-timeout off

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tobedoit/google-calendar-mcp",
-  "version": "1.1.17",
+  "version": "1.1.18",
   "description": "MCP server implementation for Google Calendar integration",
   "type": "module",
   "bin": {


### PR DESCRIPTION
- Claude 켜짐 → npx @tobedoit/google-calendar-mcp 한 세트 뜸 (npm exec + node)
- Claude 끔(Cmd+Q) → stdin close → MCP 서버 즉시 종료 → 고아 프로세스 X
- idle-timeout은 기본 OFF라서, 중간에 MCP가 자기 멋대로 죽어버리는 일도 없음
- CPU 0%, 배터리 영향 거의 없음
- Fixes #6 